### PR TITLE
Form for adding honey-do items to the list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem 'bootstrap-sass', '~> 3.3.7'
 gem 'slim', '~> 3.0'
 
 group :development, :test do
@@ -45,6 +46,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.6'
   gem 'factory_bot_rails', '~> 4.8'
 
+  gem 'launchy'
   gem 'pry'
   gem 'pry-byebug'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,12 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
+    autoprefixer-rails (7.2.3)
+      execjs
     bindex (0.5.0)
+    bootstrap-sass (3.3.7)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
     builder (3.2.3)
     byebug (9.1.0)
     capybara (2.16.1)
@@ -72,6 +77,8 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -210,10 +217,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootstrap-sass (~> 3.3.7)
   byebug
   capybara (~> 2.13)
   factory_bot_rails (~> 4.8)
   jbuilder (~> 2.5)
+  launchy
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
   pry

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,8 +14,16 @@
  *= require_self
  */
 
+@import 'bootstrap-sprockets';
+@import 'bootstrap';
+
 body {
   display: block;
   margin: auto;
   width: 40%;
+}
+
+.todos__title-input {
+  @extend .col-sm-8;
+  padding-left: 0;
 }

--- a/app/channels/todo_channel.rb
+++ b/app/channels/todo_channel.rb
@@ -1,0 +1,16 @@
+class TodoChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from 'todos'
+  end
+
+  def add_todo(payload)
+    todo = Todo.create(todo_params_for(payload))
+    ActionCable.server.broadcast('todos', todo.to_json)
+  end
+
+  private
+
+  def todo_params_for(payload)
+    payload.except('action')
+  end
+end

--- a/app/javascript/packs/client/cable.js
+++ b/app/javascript/packs/client/cable.js
@@ -1,0 +1,13 @@
+import cable from 'actioncable'
+
+let consumer
+
+function createChannel(...args) {
+  if (!consumer) {
+    consumer = cable.createConsumer()
+  }
+
+  return consumer.subscriptions.create(...args)
+}
+
+export default createChannel

--- a/app/javascript/packs/client/todo_channel.js
+++ b/app/javascript/packs/client/todo_channel.js
@@ -1,0 +1,19 @@
+import createChannel from './cable'
+
+let callback
+
+const chat = createChannel('TodoChannel', {
+  received(todo) {
+    if (callback) callback.call(null, todo)
+  }
+});
+
+function addTodo(todo) {
+  chat.perform('add_todo', todo)
+}
+
+function setCallback(fn) {
+  callback = fn
+}
+
+export { addTodo, setCallback }

--- a/app/javascript/packs/todos.jsx
+++ b/app/javascript/packs/todos.jsx
@@ -1,24 +1,83 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
+import {
+  addTodo,
+  setCallback
+} from './client/todo_channel'
+
 class Todos extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.createTodo = this.createTodo.bind(this)
+    this.addTodoToList = this.addTodoToList.bind(this)
+    this.state = {
+      todos: props.todos
+    }
+  }
+
+  addTodoToList(todo) {
+    const todos = [...this.state.todos].concat(todo)
+    this.setState({ todos })
+
+    const titleInput = this.refs.titleInput
+    titleInput.value = ''
+    titleInput.focus()
+  }
+
+  createTodo(event) {
+    event.preventDefault()
+    const form = this.refs.form
+    const title = this.refs.titleInput.value
+
+    addTodo({ title })
+    setCallback(todo => this.addTodoToList(JSON.parse(todo)))
+  }
+
   render() {
-    const { todos } = this.props
+    const { todos } = this.state
     return (
-      <ol id='todos'>
-        {
-          todos.map((todo) => {
-            return <li key={todo.id}>{todo.title}</li>
-          })
-        }
-      </ol>
+      <div>
+        <form
+          id='todo-form'
+          onSubmit={this.createTodo}
+          ref='form'
+        >
+          <div className='form-row'>
+            <div className='todos__title-input'>
+              <input
+                className='form-control'
+                name='todo[title]'
+                placeholder='Add a honey-do to the list'
+                ref='titleInput'
+                type='text'
+              />
+            </div>
+            <div className='col-auto'>
+              <button
+                className='btn btn-primary'
+              >
+                Add a honey-do
+              </button>
+            </div>
+          </div>
+        </form>
+        <div id='todos'>
+          {
+            todos.map((todo) => {
+              return <div key={todo.id}>{todo.title}</div>
+            })
+          }
+        </div>
+      </div>
     )
   }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  let node = document.getElementById('todos_data')
-  let data = JSON.parse(node.dataset.todos);
+  const node = document.getElementById('todos_data')
+  const data = JSON.parse(node.dataset.todos)
 
   ReactDOM.render(
     <Todos todos={data} />,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/webpacker": "^3.2.0",
+    "actioncable": "^5.1.4",
     "babel-preset-react": "^6.24.1",
     "coffeescript": "1.12.7",
     "prop-types": "^15.6.0",

--- a/spec/features/todos_list_spec.rb
+++ b/spec/features/todos_list_spec.rb
@@ -1,15 +1,31 @@
 require 'rails_helper'
 
-RSpec.feature 'Todos list', type: :feature do
-  scenario 'User views a list of todos', :js do
-    todos = 1.upto(3).map do |number|
+RSpec.feature 'Todos list', type: :system do
+  before do
+    driven_by(:headless_chrome)
+  end
+
+  let!(:todos) do
+    1.upto(3).map do |number|
       FactoryBot.create(:todo, title: "thing #{number}")
     end
+  end
 
+  scenario 'User views a list of todos' do
     visit todos_path
 
     todos.each do |todo|
       expect(page).to have_content todo.title
     end
+  end
+
+  scenario 'User adds a todo to the list' do
+    todo = FactoryBot.build(:todo, title: 'Play videogames')
+    visit todos_path
+
+    fill_in 'todo[title]', with: todo.title
+    click_button 'Add a honey-do'
+
+    expect(page).to have_content todo.title
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,6 +59,10 @@ acorn@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
+actioncable@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/actioncable/-/actioncable-5.1.4.tgz#f1751f0316b3b3530ef278bf44257efe996c4f92"
+
 ajv-keywords@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"


### PR DESCRIPTION
- Using ActionCable to pub/sub honey-do items. It feels a little overkill, but it was interesting to use ActionCable for the first time. I had some issues with csrf tokens and using the form in React, but switching to ActionCable cleared up those issues and added a nice way to subscribe and add new honey-do items easily.
- Using Bootstrap for some simple styling
- Changing from RSpec feature tests to system tests since that's the new Rails "acceptance" testing pattern. It also resolved some issues around testing the honey-do form since ActionCable wasn't working until switching to system tests.